### PR TITLE
FIX: Makefile. rule clean removes build dir, and fclean removes the bin directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,9 @@ test: $(TEST_OUT_NAME)
 
 clean:
 	$(RM) $(BUILD_DIR)
-	$(RM) $(BIN_DIR)
 
 fclean: clean
-	$(RM) $(NAME) $(TEST_OUT_NAME)
+	$(RM) $(BIN_DIR)
 
 re: fclean all
 


### PR DESCRIPTION

Fix for #10 
